### PR TITLE
feat(auth): add refresh tokens + logout endpoint

### DIFF
--- a/TaskTracker.Api/Data/AppDbContext.cs
+++ b/TaskTracker.Api/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ public sealed class AppDbContext : DbContext
     public DbSet<TaskItem> Tasks => Set<TaskItem>();
     public DbSet<Project> Projects => Set<Project>();
     public DbSet<User> Users => Set<User>();
+    public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/TaskTracker.Api/Migrations/20250905163011_AddRefreshTokens.Designer.cs
+++ b/TaskTracker.Api/Migrations/20250905163011_AddRefreshTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TaskTracker.Api.Data;
 
@@ -11,9 +12,11 @@ using TaskTracker.Api.Data;
 namespace TaskTracker.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250905163011_AddRefreshTokens")]
+    partial class AddRefreshTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/TaskTracker.Api/Migrations/20250905163011_AddRefreshTokens.cs
+++ b/TaskTracker.Api/Migrations/20250905163011_AddRefreshTokens.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TaskTracker.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRefreshTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Token = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ExpiresUtc = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "bit", nullable: false),
+                    UserId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RefreshTokens");
+        }
+    }
+}

--- a/TaskTracker.Api/Models/RefreshToken.cs
+++ b/TaskTracker.Api/Models/RefreshToken.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace TaskTracker.Api.Models;
+
+public class RefreshToken
+{
+    public int Id { get; set; }
+
+    [Required]
+    public string Token { get; set; } = string.Empty;
+
+    public DateTime ExpiresUtc { get; set; }
+    public bool IsRevoked { get; set; }
+
+    // Link to User
+    public int UserId { get; set; }
+    public User User { get; set; } = null!;
+}

--- a/TaskTracker.Api/Models/User.cs
+++ b/TaskTracker.Api/Models/User.cs
@@ -13,4 +13,7 @@ public class User
     public string PasswordHash { get; set; } = string.Empty;
 
     public string Role { get; set; } = "User"; // Default role
+
+    // Navigation property
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
 }


### PR DESCRIPTION
## Description
Add support for refresh tokens and logout

## Related Issue


## How to Test
Test in Postman

Login
POST /auth/login → copy AccessToken + RefreshToken.

Call tasks with Authorization: Bearer <AccessToken> → works.

Wait until access token expires (you can set short expiry, like 1 min, in Program.cs for testing).

Refresh
POST /auth/refresh → send raw string body = "<RefreshToken>".
Returns new access token.

Logout
POST /auth/logout with refresh token.
Then try /auth/refresh again with same token → Unauthorized.

## Screenshots (if UI-related)
<!-- Before/After images, or N/A if not applicable -->

## Checklist
- [ x] Code builds without errors
- [ ] Tests added or updated
- [x ] All tests passing locally
- [ ] Screenshots included if UI changes
