### PR TITLE
(chore): delete unnecessary deploy yaml

### DIFF
--- a/TaskTracker.sln
+++ b/TaskTracker.sln
@@ -10,7 +10,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		.dockerignore = .dockerignore
 		k8s\api-deployment.yaml = k8s\api-deployment.yaml
 		k8s\api-service.yaml = k8s\api-service.yaml
-		.github\workflows\deploy.yml = .github\workflows\deploy.yml
 		docker-compose.override.yml = docker-compose.override.yml
 		docker-compose.yml = docker-compose.yml
 		Dockerfile = Dockerfile


### PR DESCRIPTION
## Description
Delete a yaml file that triggered 2 github actions deploying to Azure App Service.
Only one live deployment yaml file exists now.

## Related Issue


## How to Test
go to solution root and run dotnet test.

## Screenshots (if UI-related)


## Checklist
- [x ] Code builds without errors
- [ ] Tests added or updated
- [x ] All tests passing locally
- [ ] Screenshots included if UI changes
